### PR TITLE
docs: fix config spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Usage:
 
 Server options:
   -s,     --sample    Malware sample to analyse
-  -vm,    --agent-vm  VM to use for analysis, read from conffig file
+  -vm,    --agent-vm  VM to use for analysis, read from config file
   -ip,    --agent-ip  IP of agent to send sample to
   -r,     --result    Folder location to store analysis results in. Default ~/.sandlada/result
   -e,     --executor  Run malware with specific command, e.g. "python2.7"

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -22,8 +22,8 @@ func main() {
 
 	serverMode.StringVar(&srvOpts.Sample, "sample", "", "Malware sample to analyse")
 	serverMode.StringVar(&srvOpts.Sample, "s", "", "Malware sample to analyse")
-	serverMode.StringVar(&srvOpts.AgentVM, "agentVM", "", "VM to use for analysis, read from conffig file")
-	serverMode.StringVar(&srvOpts.AgentVM, "vm", "", "VM to use for analysis, read from conffig file")
+        serverMode.StringVar(&srvOpts.AgentVM, "agentVM", "", "VM to use for analysis, read from config file")
+        serverMode.StringVar(&srvOpts.AgentVM, "vm", "", "VM to use for analysis, read from config file")
 	serverMode.StringVar(&srvOpts.AgentIP, "agentIP", "", "IP of agent to send sample to")
 	serverMode.StringVar(&srvOpts.AgentIP, "ip", "", "IP of agent to send sample to")
 	serverMode.StringVar(&srvOpts.Database, "database", "~/.sandlada/sqlite.db", "Use local sqlite database for storing results. Default ~/.sandlada/sqlite.db")


### PR DESCRIPTION
## Summary
- correct 'config' spelling in README and cmd/main.go

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org/github.com/google/uuid@v1.2.0.mod": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68436297635c8321af45b7ad1ce9b6b3