### PR TITLE
fix: use absolute path for default sample execution

### DIFF
--- a/agent/analysis.go
+++ b/agent/analysis.go
@@ -102,6 +102,15 @@ func (c *Collection) runCommand(ctx context.Context, taskName string, commando [
 	return nil, stdout.Bytes()
 }
 
+// buildExecutionCommand returns the command used to execute the sample. If no
+// executor is specified the sample is executed directly from /tmp/binary.
+func buildExecutionCommand(executer string) string {
+	if len(executer) > 0 {
+		return fmt.Sprintf("%s /tmp/binary", executer)
+	}
+	return "/tmp/binary"
+}
+
 // BehaviorAnalysis Runs malware sample
 // Executer specifies if the sample should be run by a specific program
 // For example, some samples needs to be run as 'python2 sample.py'.
@@ -119,11 +128,7 @@ func (c *Collection) BehaviorAnalysis(ctx context.Context, executer string, wg *
 		return
 	}
 
-	if len(executer) > 0 {
-		commando = fmt.Sprintf("%s /tmp/binary", executer)
-	} else {
-		commando = "./tmp/binary"
-	}
+	commando = buildExecutionCommand(executer)
 
 	command := []string{"staprun", "-R", "-c", commando, "/opt/sandlada.ko"}
 	err, output := c.runCommand(ctx, "Behavior Analysis", command)

--- a/agent/analysis_test.go
+++ b/agent/analysis_test.go
@@ -1,0 +1,20 @@
+package agent
+
+import "testing"
+
+func TestBuildExecutionCommand(t *testing.T) {
+	tests := []struct {
+		exec string
+		want string
+	}{
+		{"", "/tmp/binary"},
+		{"python", "python /tmp/binary"},
+	}
+
+	for _, tt := range tests {
+		got := buildExecutionCommand(tt.exec)
+		if got != tt.want {
+			t.Errorf("buildExecutionCommand(%q) = %q, want %q", tt.exec, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- adjust default path for running a sample when no executor is specified
- add helper `buildExecutionCommand`
- add unit test for command generation

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org/github.com/google/uuid/@v/v1.2.0.mod": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6843629e66608321a7a44b22e17ebefb