### PR TITLE
test: verify status code in SendData

### DIFF
--- a/server/http_test.go
+++ b/server/http_test.go
@@ -157,10 +157,14 @@ func TestSendData(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	_, err := SendData(ts.URL, &expected)
+	statusCode, err := SendData(ts.URL, &expected)
 
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	if statusCode != http.StatusOK {
+		t.Errorf("expected status code %d, got %d", http.StatusOK, statusCode)
 	}
 
 	if !bytes.Equal(data.Bytes(), expected) {


### PR DESCRIPTION
## Summary
- extend `TestSendData` to check the returned HTTP status code

## Testing
- `go test ./...` *(fails: module download forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684362ec661c8321ae937ce3a3ebf22d